### PR TITLE
fix: version pattern for CCv2 build.version

### DIFF
--- a/src/mpern/sap/commerce/build/util/Version.java
+++ b/src/mpern/sap/commerce/build/util/Version.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Version implements Comparable<Version> {
-    private static final Pattern NEW_VERSION = Pattern.compile("(\\d\\d)(\\d\\d)(\\.([1-9]?\\d))?");
+    private static final Pattern NEW_VERSION = Pattern.compile("(\\d\\d)(\\d\\d)(\\.([1-9]?\\d))?.*");
     private static final Pattern OLD_VERSION = Pattern.compile("(\\d)\\.(\\d)\\.(\\d)(\\.([1-9]?\\d))?");
     public static final int UNDEFINED_PART = Integer.MAX_VALUE;
     public static final Version UNDEFINED = new Version(UNDEFINED_PART, UNDEFINED_PART, UNDEFINED_PART, UNDEFINED_PART,


### PR DESCRIPTION
CCv2 uses Version pattern "2105.10-2105-2202.26-20220510.1-cbe2a6a-develop" which causes Spring Bean initialization to fail since the current pattern for NEW_VERSION causes .match() to return false so the pods in the CCv2 won't start anymore.

BTW, some of the index definitions in the items.xml will also cause the build to fail because items like `DroolsRule` and `AbstractRule` depend on extensions that are not included out of the box like `droolsruleengineservices`, so I'm not sure if it makes sense to include these per default.